### PR TITLE
Use the Self-Hosted Runners

### DIFF
--- a/.github/workflows/beta-deployment.yml
+++ b/.github/workflows/beta-deployment.yml
@@ -22,7 +22,7 @@ jobs:
   iosapptestflightdeployment:
     name: iOS App TestFlight Deployment
     needs: buildandtest
-    uses: CS342/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
+    uses: CS342/.github/.github/workflows/xcodebuild-or-fastlane.yml@v1
     secrets: inherit
     with:
       artifactname: PAWS.xcresult

--- a/.github/workflows/beta-deployment.yml
+++ b/.github/workflows/beta-deployment.yml
@@ -21,51 +21,11 @@ jobs:
     secrets: inherit
   iosapptestflightdeployment:
     name: iOS App TestFlight Deployment
-    runs-on: macos-12
     needs: buildandtest
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        lfs: true
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: latest-stable
-    - name: Check Environment
-      run: |
-          xcodebuild -version
-          swift --version
-    - name: Install the Apple certificate and provisioning profile
-      env:
-        BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
-        P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
-        BUILD_PROVISION_PROFILE_BASE64: ${{ secrets.BUILD_PROVISION_PROFILE_BASE64 }}
-        KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
-      run: |
-        # create variables
-        CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
-        PP_PATH=$RUNNER_TEMP/build_pp.mobileprovision
-        KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
-
-        # import certificate and provisioning profile from secrets
-        echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode --output $CERTIFICATE_PATH
-        echo -n "$BUILD_PROVISION_PROFILE_BASE64" | base64 --decode --output $PP_PATH
-
-        # create temporary keychain
-        security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-        security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
-        security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-
-        # import certificate to keychain
-        security import $CERTIFICATE_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
-        security list-keychain -d user -s $KEYCHAIN_PATH
-
-        # apply provisioning profile
-        mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-        cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles
-    - name: Build and test
-      run: bundler install && bundle exec fastlane beta
-      env:
-        APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
-        APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
-        APP_STORE_CONNECT_API_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
-        APPLE_ID: ${{ secrets.APPLE_ID }}
+    uses: CS342/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
+    secrets: inherit
+    with:
+      artifactname: PAWS.xcresult
+      runsonlabels: '["macos-latest"]'
+      fastlanelane: beta
+      setupsigning: true

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,47 +20,17 @@ jobs:
   swiftlint:
     name: SwiftLint
     uses: StanfordBDHG/.github/.github/workflows/swiftlint.yml@v1
-  buildandtestiosapp:
-    name: Build and Test iOS App
-    runs-on: macos-12
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        lfs: true
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: latest-stable
-    - name: Check Environment
-      run: |
-          xcodebuild -version
-          swift --version
-    - name: Cache Firebase Emulators
-      uses: actions/cache@v3
-      with:
-        path: ~/.cache/firebase/emulators
-        key: ${{ runner.os }}-firebase-emulators-${{ hashFiles('~/.cache/firebase/emulators/**') }}
-    - name: Setup NodeJS
-      uses: actions/setup-node@v3
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        distribution: 'microsoft'
-        java-version: '17'
-    - name: Install Firebase CLI Tools
-      run: npm install -g firebase-tools
-    - name: Build and Test Example App
-      run: |
-          firebase emulators:exec 'bundler install && bundle exec fastlane test'
-    - name: Upload Artifact
-      if: always()
-      uses: actions/upload-artifact@v3
-      with:
-        name: PAWS.xcresult
-        path: PAWS.xcresult
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
-      with:
-        fail_ci_if_error: true
-        token: ${{ secrets.CODECOV_TOKEN }}
-        xcode: true
-        xcode_archive_path: PAWS.xcresult
+  buildandtest:
+    name: Build and Test
+    uses: CS342/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
+    with:
+      artifactname: PAWS.xcresult
+      runsonlabels: '["macOS", "self-hosted"]'
+      setupfirebaseemulator: true
+      customcommand: "firebase emulators:exec 'fastlane test'"
+  uploadcoveragereport:
+    name: Upload Coverage Report
+    needs: buildandtest
+    uses: StanfordBDHG/.github/.github/workflows/create-and-upload-coverage-report.yml@v2
+    with:
+      coveragereports: PAWS.xcresult

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,13 +16,13 @@ on:
 jobs:
   reuse_action:
     name: REUSE Compliance Check
-    uses: StanfordBDHG/.github/.github/workflows/reuse.yml@v1
+    uses: StanfordBDHG/.github/.github/workflows/reuse.yml@v2
   swiftlint:
     name: SwiftLint
-    uses: StanfordBDHG/.github/.github/workflows/swiftlint.yml@v1
+    uses: StanfordBDHG/.github/.github/workflows/swiftlint.yml@v2
   buildandtest:
     name: Build and Test
-    uses: CS342/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
+    uses: CS342/.github/.github/workflows/xcodebuild-or-fastlane.yml@v1
     with:
       artifactname: PAWS.xcresult
       runsonlabels: '["macOS", "self-hosted"]'

--- a/PAWS.xcodeproj/project.pbxproj
+++ b/PAWS.xcodeproj/project.pbxproj
@@ -770,7 +770,7 @@
 			repositoryURL = "https://github.com/StanfordBDHG/CardinalKit";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.3.0;
+				minimumVersion = 0.3.2;
 			};
 		};
 		2F4E237F2989C5930013F3D9 /* XCRemoteSwiftPackageReference "XCTHealthKit" */ = {
@@ -778,7 +778,7 @@
 			repositoryURL = "https://github.com/StanfordBDHG/XCTHealthKit";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.3.1;
+				minimumVersion = 0.3.3;
 			};
 		};
 		2FABBC5729A8975900DF3BBC /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {

--- a/PAWSModules/Sources/PAWSMockDataStorageProvider/Bundle+ECGTracing.swift
+++ b/PAWSModules/Sources/PAWSMockDataStorageProvider/Bundle+ECGTracing.swift
@@ -8,7 +8,6 @@
 
 import FHIR
 import Foundation
-import HealthKitOnFHIR
 
 
 extension Foundation.Bundle {

--- a/PAWSModules/Sources/PAWSMockDataStorageProvider/LazyText.swift
+++ b/PAWSModules/Sources/PAWSMockDataStorageProvider/LazyText.swift
@@ -6,8 +6,9 @@
 // SPDX-License-Identifier: MIT
 //
 
-import HealthKitOnFHIR
+import FHIR
 import SwiftUI
+
 
 struct LazyText: View {
     private let text: String

--- a/PAWSModules/Sources/PAWSMockDataStorageProvider/MockUploadDetailView.swift
+++ b/PAWSModules/Sources/PAWSMockDataStorageProvider/MockUploadDetailView.swift
@@ -6,7 +6,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-import HealthKitOnFHIR
 import SwiftUI
 
 
@@ -19,9 +18,8 @@ struct MockUploadDetailView: View {
             Section(String(localized: "MOCK_UPLOAD_DETAIL_HEADER", bundle: .module)) {
                 MockUploadHeader(mockUpload: mockUpload)
             }
-            
             Section(String(localized: "MOCK_UPLOAD_DETAIL_BODY", bundle: .module)) {
-            LazyText(text: mockUpload.body ?? "")
+                LazyText(text: mockUpload.body ?? "")
             }
         }
             .listStyle(.insetGrouped)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -18,6 +18,7 @@ platform :ios do
   lane :test do
     run_tests(
       code_coverage: true,
+      derived_data_path: ".derivedData",
       result_bundle: true,
       output_directory: "."
     )
@@ -25,7 +26,9 @@ platform :ios do
 
   desc "Build app"
   lane :build do
-    build_app
+    build_app(
+      derived_data_path: ".derivedData"
+    )
   end
 
   desc "Sign in to the App Store Connect API"


### PR DESCRIPTION
# Use the Self-Hosted Runners

## :bulb: Proposed solution
- Switches to a reusable workflow and uses the self-hosted runners.


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).

