### PR TITLE
removed non ECG data from health permissions

### DIFF
--- a/PAWS/PAWSAppDelegate.swift
+++ b/PAWS/PAWSAppDelegate.swift
@@ -65,18 +65,6 @@ class PAWSAppDelegate: CardinalKitAppDelegate {
     private var healthKit: HealthKit<FHIR> {
         HealthKit {
             CollectSample(
-                HKQuantityType(.heartRate),
-                deliverySetting: .anchorQuery(.afterAuthorizationAndApplicationWillLaunch)
-            )
-            CollectSample(
-                HKQuantityType(.heartRateVariabilitySDNN),
-                deliverySetting: .anchorQuery(.afterAuthorizationAndApplicationWillLaunch)
-            )
-            CollectSample(
-                HKQuantityType(.restingHeartRate),
-                deliverySetting: .anchorQuery(.afterAuthorizationAndApplicationWillLaunch)
-            )
-            CollectSample(
                 HKQuantityType.electrocardiogramType(),
                 deliverySetting: .anchorQuery(.afterAuthorizationAndApplicationWillLaunch)
             )

--- a/PAWSModules/Sources/PAWSHomeScreen/HomeScreen.swift
+++ b/PAWSModules/Sources/PAWSHomeScreen/HomeScreen.swift
@@ -7,7 +7,7 @@
 //
 
 import SwiftUI
-
+import FirebaseAuth
 
 public struct HomeScreen: View {
     private let backgroundGradient = LinearGradient(
@@ -24,7 +24,7 @@ public struct HomeScreen: View {
                             .padding([.top], 10)
                             .font(.title)
                             .fontWeight(.bold)
-                        Text("Your Name!")
+                        Text("Your Name")
                             .font(.title2)
                             .fontWeight(.bold)
                             .padding([.top], 0)


### PR DESCRIPTION
<!--

This source file is part of the Stanford CS342 - Building for Digital Health class

SPDX-FileCopyrightText: 2022 Stanford University

SPDX-License-Identifier: MIT

-->

# removed non-ECG health data

## :recycle: Current situation & Problem
*Describe the current situation (if possible, with an exemplary (or real) code snippet and/or where this is used)*
*Please link any open issue that is addressed with this PR*

Previously included sharing permissions for non-ECG data (heart rate, etc.) that caused overload of data in reports tab. 

## :bulb: Proposed solution
*Describe the solution and how this affects the project and internal structure*

Removed non-ECG data from sharing permissions screen. 

## :gear: Release Notes 
*Add a summary of the feature and possible migration guides if this is a breaking change so this section can be added to the release notes.*
*Include code snippets that provide examples of the feature implemented if it appends or changes the public interface.*

## :heavy_plus_sign: Additional Information
*Provide some additional information if possible*

### Related PRs
*Reference the related PRs*

### Testing
*Are there tests included? If yes, which situations are tested, and which corner cases are missing?*

### Reviewer Nudging
*Where should the reviewer start? Where is a good entry point?*

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [ +] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).

