### PR TITLE
Added functionality for creating a document in Firestore with every new user signup

### DIFF
--- a/PAWSModules/Sources/PAWSOnboardingFlow/AccountSetup/AccountSetup.swift
+++ b/PAWSModules/Sources/PAWSOnboardingFlow/AccountSetup/AccountSetup.swift
@@ -9,6 +9,8 @@
 import Account
 import class FHIR.FHIR
 import FirebaseAccount
+import FirebaseAuth
+import FirebaseFirestore
 import Onboarding
 import SwiftUI
 
@@ -42,6 +44,19 @@ struct AccountSetup: View {
             .onReceive(account.objectWillChange) {
                 if account.signedIn {
                     onboardingSteps.append(.healthKitPermissions)
+                    
+                    if let user = Auth.auth().currentUser {
+                        let uid = user.uid
+                        let name = user.displayName?.components(separatedBy: " ")
+                        let firstName = name?[0] ?? ""
+                        let lastName = name?[1] ?? ""
+                        let data: [String: Any] = ["firstName": firstName, "id": uid, "lastName": lastName]
+                        Firestore.firestore().collection("users").document(uid).setData(data) { err in
+                            if let err = err {
+                                print("Error updating document: \(err)")
+                            }
+                        }
+                    }
                     // Unfortunately, SwiftUI currently animates changes in the navigation path that do not change
                     // the current top view. Therefore we need to do the following async procedure to remove the
                     // `.login` and `.signUp` steps while disabling the animations before and re-enabling them


### PR DESCRIPTION
<!--

This source file is part of the Stanford CS342 - Building for Digital Health class

SPDX-FileCopyrightText: 2022 Stanford University

SPDX-License-Identifier: MIT

-->

# Added functionality for creating a document in Firestore with every new user signup

## :recycle: Current situation & Problem
Need to create a document in Firestore with user information every time a new user signs up.

## :bulb: Proposed solution
Added some code in the Account Setup section.

## :gear: Release Notes 
*Add a summary of the feature and possible migration guides if this is a breaking change so this section can be added to the release notes.*
*Include code snippets that provide examples of the feature implemented if it appends or changes the public interface.*

## :heavy_plus_sign: Additional Information
*Provide some additional information if possible*

### Related PRs
*Reference the related PRs*

### Testing
*Are there tests included? If yes, which situations are tested, and which corner cases are missing?*

### Reviewer Nudging
*Where should the reviewer start? Where is a good entry point?*

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [ ] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).

