### PR TITLE
Background Delivery, Release Build Fix, and Full ECG Recording

### DIFF
--- a/PAWS.xcodeproj/project.pbxproj
+++ b/PAWS.xcodeproj/project.pbxproj
@@ -780,7 +780,7 @@
 			repositoryURL = "https://github.com/StanfordBDHG/CardinalKitHealthKitToFHIRAdapter";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.1.0;
+				minimumVersion = 0.1.1;
 			};
 		};
 		2FABBC5729A8975900DF3BBC /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {

--- a/PAWS/PAWSAppDelegate.swift
+++ b/PAWS/PAWSAppDelegate.swift
@@ -65,7 +65,7 @@ class PAWSAppDelegate: CardinalKitAppDelegate {
         HealthKit {
             CollectSample(
                 HKQuantityType.electrocardiogramType(),
-                deliverySetting: .anchorQuery(.afterAuthorizationAndApplicationWillLaunch)
+                deliverySetting: .background(.afterAuthorizationAndApplicationWillLaunch)
             )
             CollectSamples(Set(HKElectrocardiogram.correlatedSymptomTypes))
         } adapter: {

--- a/PAWSModules/Package.swift
+++ b/PAWSModules/Package.swift
@@ -27,7 +27,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/StanfordBDHG/CardinalKit.git", .upToNextMinor(from: "0.3.5")),
-        .package(url: "https://github.com/firebase/firebase-ios-sdk.git", from: "10.5.0")
+        .package(url: "https://github.com/firebase/firebase-ios-sdk.git", from: "10.5.0"),
+        .package(url: "https://github.com/apple/FHIRModels.git", .upToNextMajor(from: "0.4.0"))
     ],
     targets: [
         .target(
@@ -50,7 +51,8 @@ let package = Package(
                 .product(name: "FirestoreDataStorage", package: "firebase-ios-sdk"),
                 .product(name: "FirebaseFirestore", package: "firebase-ios-sdk"),
                 .product(name: "FirebaseFirestoreSwift", package: "firebase-ios-sdk"),
-                .product(name: "FirebaseAuth", package: "firebase-ios-sdk")
+                .product(name: "FirebaseAuth", package: "firebase-ios-sdk"),
+                .product(name: "ModelsR4", package: "fhirmodels")
             ],
             resources: [
                 .process("Resources")

--- a/PAWSModules/Sources/PAWSMockDataStorageProvider/Bundle+ECGTracing.swift
+++ b/PAWSModules/Sources/PAWSMockDataStorageProvider/Bundle+ECGTracing.swift
@@ -6,9 +6,9 @@
 // SPDX-License-Identifier: MIT
 //
 
-import FHIR
 import Foundation
-import HealthKitOnFHIR
+import ModelsR4
+
 
 extension Foundation.Bundle {
     func ecgTracing(withName name: String) -> Observation {

--- a/PAWSModules/Sources/PAWSMockDataStorageProvider/MockDataStorageProvider.swift
+++ b/PAWSModules/Sources/PAWSMockDataStorageProvider/MockDataStorageProvider.swift
@@ -13,7 +13,6 @@ import FirebaseCore
 import FirebaseFirestore
 import FirestoreDataStorage
 import Foundation
-import HealthKitOnFHIR
 import HealthKitUI
 
 /// A data storage provider that collects all uploads and displays them in a user interface using the ``MockUploadList``.

--- a/PAWSModules/Sources/PAWSMockDataStorageProvider/MockUpload.swift
+++ b/PAWSModules/Sources/PAWSMockDataStorageProvider/MockUpload.swift
@@ -11,7 +11,6 @@ import FirebaseCore
 import FirebaseFirestore
 import FirestoreDataStorage
 import Foundation
-import HealthKitOnFHIR
 
 
 struct MockUpload: Identifiable, Hashable {

--- a/PAWSModules/Sources/PAWSMockDataStorageProvider/MockUploadHeader.swift
+++ b/PAWSModules/Sources/PAWSMockDataStorageProvider/MockUploadHeader.swift
@@ -85,8 +85,8 @@ struct MockUploadHeader: View {
                 .padding(.top, 2)
                 .padding([.bottom], 3)
                 .padding([.leading], 2)
-            ForEach (0..<(symptoms.count - 1)){ index in
-                Text(symptoms[index])
+            ForEach(symptoms) { symptom in
+                Text(symptom)
                     .font(.subheadline)
                     .padding(.top, -4)
                     .padding(.bottom, -4)


### PR DESCRIPTION
# Background Delivery, Release Build Fix, and Full ECG Recording 

## :recycle: Current situation & Problem
- The application currently does not collect the ECG observations while the application is not running.
- The release build is currently failing due to missing HealthKitOnFHIR imports
- The ECG recordings currently only encode 15 seconds of the encodings

## :bulb: Proposed solution
- Enables background delivery for HealthKit data
- Fixes the release builds by improving and specifying the necessary imports
- Updates the dependencies to benefit from newer fixes in HealthKitOnFHIR and the HealthKit to FHIR adapter

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).

