### PR TITLE
Supplemental Metrics for ECG Reading

### DIFF
--- a/PAWS/PAWSDelegate.swift
+++ b/PAWS/PAWSDelegate.swift
@@ -92,6 +92,16 @@ class PAWSDelegate: SpeziAppDelegate {
                 predicate: sharedPredicate,
                 deliverySetting: .background(saveAnchor: false)
             )
+            CollectSample(
+                HKQuantityType(.heartRate),
+                predicate: sharedPredicate,
+                deliverySetting: .background(saveAnchor: false)
+            )
+            CollectSample(
+                HKQuantityType(.vo2Max),
+                predicate: sharedPredicate,
+                deliverySetting: .background(saveAnchor: false)
+            )
         }
     }
 }


### PR DESCRIPTION
# Supplemental Metrics for ECG Reading

## :recycle: Current situation & Problem
Building on top of #40, this pull request seeks to package ECG readings with supplemental information like VO2 max and pulse rate in a way that is sensitive to the possible limitations of current recording capabilities.


## :gear: Release Notes 
- Measures most recent VO2 max known at the time of ECG recording.
- Captures pulse rate via optical sensor at T-minus five minutes and T-plus five minutes.
- Captures activity metrics at T-minus five minutes and T-plus five minutes, inlcuding:
  - Active calories.
  - Step count.
  - Standing minutes.
- Collects readings of heart rate from optical sensor at intervals of 10 minutes for first two days of the study.
- Estimates amount of time watch has been worn each day.


## :books: Documentation
In-line documentation will be written in relevant files in conformance to the [Spezi Documentation Guide](https://github.com/StanfordSpezi/.github/blob/main/DOCUMENTATIONGUIDE.md).


## :white_check_mark: Testing
Tests may be added for ensuring that data is correctly serialized and properly handled.


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
