### PR TITLE
Specific Upload Error Handling

### DIFF
--- a/PAWS/PAWSStandard.swift
+++ b/PAWS/PAWSStandard.swift
@@ -95,7 +95,11 @@ actor PAWSStandard: Standard, EnvironmentAccessible, HealthKitConstraint, Onboar
             }
             
             for supplementalMetric in supplementalMetrics {
-                try? await upload(sample: supplementalMetric)
+                do {
+                    try await upload(sample: supplementalMetric)
+                } catch {
+                    logger.log("Could not upload \(supplementalMetric.sampleType): \(error)")
+                }
             }
         } catch {
             logger.log("Could not access HealthKit sample: \(error)")

--- a/PAWS/PAWSStandard.swift
+++ b/PAWS/PAWSStandard.swift
@@ -95,7 +95,7 @@ actor PAWSStandard: Standard, EnvironmentAccessible, HealthKitConstraint, Onboar
             }
             
             for supplementalMetric in supplementalMetrics {
-                try await upload(sample: supplementalMetric)
+                try? await upload(sample: supplementalMetric)
             }
         } catch {
             logger.log("Could not access HealthKit sample: \(error)")

--- a/PAWS/PAWSStandard.swift
+++ b/PAWS/PAWSStandard.swift
@@ -81,38 +81,24 @@ actor PAWSStandard: Standard, EnvironmentAccessible, HealthKitConstraint, Onboar
     
     private func upload(electrocardiogram: HKElectrocardiogram) async {
         var supplementalMetrics: [HKSample] = []
-        var precedingPulseRates: [HKQuantitySample] = []
-        var precedingPhysicalEffort: [HKQuantitySample] = []
-        var precedingStepCount: [HKQuantitySample] = []
-        var precedingActiveEnergy: [HKQuantitySample] = []
-        var precedingVo2Max: HKQuantitySample?
         
         do {
             try await upload(sample: electrocardiogram)
-            precedingPulseRates = try await electrocardiogram.precedingPulseRates
-            precedingPhysicalEffort = try await electrocardiogram.precedingPhysicalEffort
-            precedingStepCount = try await electrocardiogram.precedingStepCount
-            precedingActiveEnergy = try await electrocardiogram.precedingActiveEnergy
-            precedingVo2Max = try await electrocardiogram.precedingVo2Max
+            
+            supplementalMetrics.append(contentsOf: (try? await electrocardiogram.precedingPulseRates) ?? [])
+            supplementalMetrics.append(contentsOf: (try? await electrocardiogram.precedingPhysicalEffort) ?? [])
+            supplementalMetrics.append(contentsOf: (try? await electrocardiogram.precedingStepCount) ?? [])
+            supplementalMetrics.append(contentsOf: (try? await electrocardiogram.precedingActiveEnergy) ?? [])
+            
+            if let precedingVo2Max = try? await electrocardiogram.precedingVo2Max {
+                supplementalMetrics.append(precedingVo2Max)
+            }
+            
+            for supplementalMetric in supplementalMetrics {
+                try await upload(sample: supplementalMetric)
+            }
         } catch {
             logger.log("Could not access HealthKit sample: \(error)")
-        }
-        
-        supplementalMetrics.append(contentsOf: precedingPulseRates)
-        supplementalMetrics.append(contentsOf: precedingPhysicalEffort)
-        supplementalMetrics.append(contentsOf: precedingStepCount)
-        supplementalMetrics.append(contentsOf: precedingActiveEnergy)
-        
-        if let precedingVo2Max {
-            supplementalMetrics.append(precedingVo2Max)
-        }
-
-        for supplementalMetric in supplementalMetrics {
-            do {
-                try await upload(sample: supplementalMetric)
-            } catch {
-                logger.log("Could not upload \(supplementalMetric.sampleType): \(error)")
-            }
         }
     }
     


### PR DESCRIPTION
# Specific Upload Error Handling

## :recycle: Current situation & Problem
Previously, uploads of `HKQuantityTypeIdentifierPhysicalEffort` were throwing errors before the other samples could be uploaded.


## :gear: Release Notes 
Now that there is separation of concerns between computing properties of ECGs and uploading them, valid samples will still be successfully uploaded, even if other samples throw `HealthKitOnFHIR.HealthKitOnFHIRError.notSupported`.


## :books: Documentation
Next steps will involve adding new support for some samples to HealthKitOnFHIR and updating the documentation of [supported quantity sample types](https://swiftpackageindex.com/stanfordbdhg/healthkitonfhir/0.2.5/documentation/healthkitonfhir/supportedhkquantitytypes).


## :white_check_mark: Testing
Uploaded requests can be viewed in the Mock Web Service tab while debugging.


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
