### PR TITLE
Patient Age Group

### DIFF
--- a/PAWS.xcodeproj/project.pbxproj
+++ b/PAWS.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		A9D83F962B083794000D0C78 /* SpeziFirebaseAccountStorage in Frameworks */ = {isa = PBXBuildFile; productRef = A9D83F952B083794000D0C78 /* SpeziFirebaseAccountStorage */; };
 		A9DFE8A92ABE551400428242 /* AccountButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DFE8A82ABE551400428242 /* AccountButton.swift */; };
 		A9FE7AD02AA39BAB0077B045 /* AccountSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9FE7ACF2AA39BAB0077B045 /* AccountSheet.swift */; };
+		B28A0DDC2BA4AEDE0068258D /* Date+Bool.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28A0DDB2BA4AEDE0068258D /* Date+Bool.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -143,6 +144,7 @@
 		A9720E422ABB68CC00872D23 /* AccountSetupHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSetupHeader.swift; sourceTree = "<group>"; };
 		A9DFE8A82ABE551400428242 /* AccountButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountButton.swift; sourceTree = "<group>"; };
 		A9FE7ACF2AA39BAB0077B045 /* AccountSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSheet.swift; sourceTree = "<group>"; };
+		B28A0DDB2BA4AEDE0068258D /* Date+Bool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Bool.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -280,6 +282,7 @@
 				2FE5DC4229EDD7F2004B9AB4 /* Binding+Negate.swift */,
 				2FCC1DCA2B6A2B2700C686BE /* Date+RawRepresentable.swift */,
 				2FE5DC4329EDD7F2004B9AB4 /* Bundle+Image.swift */,
+				B28A0DDB2BA4AEDE0068258D /* Date+Bool.swift */,
 				2FE5DC4429EDD7F2004B9AB4 /* CodableArray+RawRepresentable.swift */,
 			);
 			path = Helper;
@@ -579,6 +582,7 @@
 				2FC975A82978F11A00BA99FE /* Home.swift in Sources */,
 				A9DFE8A92ABE551400428242 /* AccountButton.swift in Sources */,
 				2FE5DC3729EDD7CA004B9AB4 /* OnboardingFlow.swift in Sources */,
+				B28A0DDC2BA4AEDE0068258D /* Date+Bool.swift in Sources */,
 				2FF53D8D2A8729D600042B76 /* PAWSStandard.swift in Sources */,
 				2FE5DC4729EDD7F2004B9AB4 /* CodableArray+RawRepresentable.swift in Sources */,
 				A9720E432ABB68CC00872D23 /* AccountSetupHeader.swift in Sources */,

--- a/PAWS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PAWS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk.git",
       "state" : {
-        "revision" : "f91c8167141d0279726c6f6d9d4a47c026785cbc",
-        "version" : "10.21.0"
+        "revision" : "be49849dcba96f2b5ee550d4eceb2c0fa27dade4",
+        "version" : "10.22.1"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "cb8617fab75d181270a1d8f763f26b15c73e2e1e",
-        "version" : "10.21.0"
+        "revision" : "482cfa4e5880f0a29f66ecfd60c5a62af28bd1f0",
+        "version" : "10.22.1"
       }
     },
     {

--- a/PAWS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PAWS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "4215a748079614ed67aab303326e024c420507be5020eb9239ee1daf68db0025",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -104,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordBDHG/HealthKitOnFHIR.git",
       "state" : {
-        "revision" : "825e96007d83ed83f81ee49eb3ebab29d7b7ba2f",
-        "version" : "0.2.5"
+        "revision" : "00d64d38a8f0d826ee9e27b6f3ce32314a29fd3e",
+        "version" : "0.2.6"
       }
     },
     {
@@ -361,5 +362,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/PAWS/Helper/Date+Bool.swift
+++ b/PAWS/Helper/Date+Bool.swift
@@ -1,0 +1,21 @@
+//
+// This source file is part of the PAWS application based on the Stanford Spezi Template Application project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+
+extension Date {
+    var isAdultDateOfBirth: Bool {
+        let ageComponents = Calendar.current.dateComponents([.year], from: self, to: .now)
+        guard let ageYears = ageComponents.year else {
+            return false
+        }
+        
+        return ageYears >= 18
+    }
+}

--- a/PAWS/PAWSStandard.swift
+++ b/PAWS/PAWSStandard.swift
@@ -234,9 +234,8 @@ actor PAWSStandard: Standard, EnvironmentAccessible, HealthKitConstraint, Onboar
         if let dob = details.dateOfBrith {
             let ageComponents = Calendar.current.dateComponents([.year], from: dob, to: .now)
             // Store whether the participant is older or younger than 18.
-            if let age = ageComponents.year,
-               let ageGroupData = try? JSONEncoder().encode(age >= 18) {
-                _ = try await userBucketReference.child("ageGroup/isAdult").putDataAsync(ageGroupData)
+            if let age = ageComponents.year {
+                try await userDocumentReference.getDocument().setValue(age >= 18, forKey: "ageGroupIsAdult")
             }
         }
         

--- a/PAWS/PAWSStandard.swift
+++ b/PAWS/PAWSStandard.swift
@@ -231,6 +231,15 @@ actor PAWSStandard: Standard, EnvironmentAccessible, HealthKitConstraint, Onboar
         guard let accountStorage else {
             preconditionFailure("Account Storage was requested although not enabled in current configuration.")
         }
+        if let dob = details.dateOfBrith {
+            let ageComponents = Calendar.current.dateComponents([.year], from: dob, to: .now)
+            // Store whether the participant is older or younger than 18.
+            if let age = ageComponents.year,
+               let ageGroupData = try? JSONEncoder().encode(age >= 18) {
+                _ = try await userBucketReference.child("ageGroup/isAdult").putDataAsync(ageGroupData)
+            }
+        }
+        
         try await accountStorage.create(identifier, details)
     }
 

--- a/PAWS/PAWSStandard.swift
+++ b/PAWS/PAWSStandard.swift
@@ -232,11 +232,8 @@ actor PAWSStandard: Standard, EnvironmentAccessible, HealthKitConstraint, Onboar
             preconditionFailure("Account Storage was requested although not enabled in current configuration.")
         }
         if let dob = details.dateOfBrith {
-            let ageComponents = Calendar.current.dateComponents([.year], from: dob, to: .now)
             // Store whether the participant is older or younger than 18.
-            if let age = ageComponents.year {
-                try await userDocumentReference.getDocument().setValue(age >= 18, forKey: "ageGroupIsAdult")
-            }
+            try await userDocumentReference.getDocument().setValue(dob.isAdultDateOfBirth, forKey: "ageGroupIsAdult")
         }
         
         try await accountStorage.create(identifier, details)

--- a/PAWSTests/PAWSTests.swift
+++ b/PAWSTests/PAWSTests.swift
@@ -21,18 +21,31 @@ class PAWSTests: XCTestCase {
         components.hour = 0
         components.minute = 0
         components.second = 0
-        let dateOfBirth = Calendar.current.date(from: components)
-        XCTAssertNotNil(dateOfBirth)
-        let ageYears = Calendar.current.dateComponents([.year], from: dateOfBirth!, to: .now).year
-        XCTAssertNotNil(ageYears)
-        XCTAssertTrue(ageYears! >= 18)
+
+        guard let dateOfBirth = Calendar.current.date(from: components) else {
+            XCTFail("Could not initialize date of birth.")
+            return
+        }
+        
+        guard let ageYears = Calendar.current.dateComponents([.year], from: dateOfBirth, to: .now).year else {
+            XCTFail("Could not calculate age.")
+            return
+        }
+        
+        XCTAssertTrue(ageYears >= 18, "Age is below 18 years.")
     }
 
     func testAgeGroupIsAdultFalse() async throws {
-        let dateOfBirth = Calendar.current.date(byAdding: .year, value: -12, to: .now)
-        XCTAssertNotNil(dateOfBirth)
-        let ageYears = Calendar.current.dateComponents([.year], from: dateOfBirth!, to: .now).year
-        XCTAssertNotNil(ageYears)
-        XCTAssertFalse(ageYears! >= 18)
+        guard let dateOfBirth = Calendar.current.date(byAdding: .year, value: -12, to: .now) else {
+            XCTFail("Could not initialize date of birth.")
+            return
+        }
+        
+        guard let ageYears = Calendar.current.dateComponents([.year], from: dateOfBirth, to: .now).year else {
+            XCTFail("Could not calculate age.")
+            return
+        }
+        
+        XCTAssertFalse(ageYears >= 18, "Age is 18 years or older; expected younger.")
     }
 }

--- a/PAWSTests/PAWSTests.swift
+++ b/PAWSTests/PAWSTests.swift
@@ -8,10 +8,31 @@
 
 @testable import PAWS
 import XCTest
+import Firebase
+import SpeziAccount
 
 
 class PAWSTests: XCTestCase {
-    func testExample() throws {
-        XCTAssertTrue(true)
+    func testAgeGroupIsAdultTrue() async throws {
+        var components = DateComponents()
+        components.year = 1970
+        components.month = 1
+        components.day = 1
+        components.hour = 0
+        components.minute = 0
+        components.second = 0
+        let dateOfBirth = Calendar.current.date(from: components)
+        XCTAssertNotNil(dateOfBirth)
+        let ageYears = Calendar.current.dateComponents([.year], from: dateOfBirth!, to: .now).year
+        XCTAssertNotNil(ageYears)
+        XCTAssertTrue(ageYears! >= 18)
+    }
+
+    func testAgeGroupIsAdultFalse() async throws {
+        let dateOfBirth = Calendar.current.date(byAdding: .year, value: -12, to: .now)
+        XCTAssertNotNil(dateOfBirth)
+        let ageYears = Calendar.current.dateComponents([.year], from: dateOfBirth!, to: .now).year
+        XCTAssertNotNil(ageYears)
+        XCTAssertFalse(ageYears! >= 18)
     }
 }

--- a/PAWSTests/PAWSTests.swift
+++ b/PAWSTests/PAWSTests.swift
@@ -11,7 +11,7 @@ import XCTest
 
 
 class PAWSTests: XCTestCase {
-    func testAgeGroupIsAdultTrue() async throws {
+    func testAgeGroupIsAdultTrue() throws {
         var components = DateComponents()
         components.year = 1970
         components.month = 1
@@ -33,7 +33,7 @@ class PAWSTests: XCTestCase {
         XCTAssertTrue(ageYears >= 18, "Age is below 18 years.")
     }
 
-    func testAgeGroupIsAdultFalse() async throws {
+    func testAgeGroupIsAdultFalse() throws {
         guard let dateOfBirth = Calendar.current.date(byAdding: .year, value: -12, to: .now) else {
             XCTFail("Could not initialize date of birth.")
             return

--- a/PAWSTests/PAWSTests.swift
+++ b/PAWSTests/PAWSTests.swift
@@ -11,7 +11,7 @@ import XCTest
 
 
 class PAWSTests: XCTestCase {
-    func testAgeGroupIsAdultTrue() throws {
+    func testAdultDateOfBirthTrue() throws {
         var components = DateComponents()
         components.year = 1970
         components.month = 1
@@ -24,26 +24,16 @@ class PAWSTests: XCTestCase {
             XCTFail("Could not initialize date of birth.")
             return
         }
-        
-        guard let ageYears = Calendar.current.dateComponents([.year], from: dateOfBirth, to: .now).year else {
-            XCTFail("Could not calculate age.")
-            return
-        }
-        
-        XCTAssertTrue(ageYears >= 18, "Age is below 18 years.")
+
+        XCTAssertTrue(dateOfBirth.isAdultDateOfBirth, "Age is below 18 years.")
     }
 
-    func testAgeGroupIsAdultFalse() throws {
+    func testAdultDateOfBirthFalse() throws {
         guard let dateOfBirth = Calendar.current.date(byAdding: .year, value: -12, to: .now) else {
             XCTFail("Could not initialize date of birth.")
             return
         }
         
-        guard let ageYears = Calendar.current.dateComponents([.year], from: dateOfBirth, to: .now).year else {
-            XCTFail("Could not calculate age.")
-            return
-        }
-        
-        XCTAssertFalse(ageYears >= 18, "Age is 18 years or older; expected younger.")
+        XCTAssertFalse(dateOfBirth.isAdultDateOfBirth, "Age is 18 years or older; expected younger.")
     }
 }

--- a/PAWSTests/PAWSTests.swift
+++ b/PAWSTests/PAWSTests.swift
@@ -8,8 +8,6 @@
 
 @testable import PAWS
 import XCTest
-import Firebase
-import SpeziAccount
 
 
 class PAWSTests: XCTestCase {


### PR DESCRIPTION
# Patient Age Group

## :recycle: Current situation & Problem
We need a way to determine whether a patient is part of the upcoming pediatric study or the upcoming adult study so that UI can be updated accordingly.


## :gear: Release Notes 
- Adds the logic for tagging patients for pediatric/adult study based on date of birth and time of account creation. This information is stored in Firebase for later use in layout of the UI.

## :white_check_mark: Testing
Because of the `guard` statement at the beginning of the function body of interest, the bulk of the meaningful testing will be manual inspections of Firebase.


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
